### PR TITLE
Enable SSL for Jenkins plugin to ship build logs to kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>2.37</version>
+     <relativePath />
   </parent>
 
   <repositories>
@@ -36,7 +37,7 @@
 
   <artifactId>kafkalogs</artifactId>
   <packaging>hpi</packaging>
-  <version>0.1.7-SNAPSHOT</version>
+  <version>0.1.7</version>
   <name>Kafka Logs Plugin</name>
   <description>Distributes Build Logs to Kafka Servers</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Kafkalogs+Plugin</url>

--- a/src/main/java/hudson/plugins/kafkalogs/KafkaSslBuildWrapper.java
+++ b/src/main/java/hudson/plugins/kafkalogs/KafkaSslBuildWrapper.java
@@ -1,0 +1,166 @@
+/**
+ * 
+ */
+package hudson.plugins.kafkalogs;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.logging.Logger;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.console.ConsoleLogFilter;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.util.FormValidation;
+import jenkins.tasks.SimpleBuildWrapper;
+import net.sf.json.JSONObject;
+
+/**
+ * @author Guneet Bhatia - 000V4T744
+ *
+ */
+public class KafkaSslBuildWrapper extends SimpleBuildWrapper implements Serializable{
+    private static final Logger LOGGER = Logger.getLogger(KafkaSslBuildWrapper.class.getName());
+
+    private final String kafkaServers;
+    private final String kafkaTopic;
+    private final String metadata;
+    private KafkaWrapper producer;
+    private int buildId;
+    private String jobName;
+    private final String securityProtocol;
+    private final String sslTruststoreLocation;
+    private final String sslTruststorePassword;
+
+    private static class CleanupDisposer extends Disposer {
+        private KafkaWrapper producer;
+        public CleanupDisposer(KafkaWrapper producer) {
+            this.producer = producer;
+        }
+
+        @Override
+        public void tearDown(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) {
+            // DO ANYTHING TO TEAR DOWN KAFKA LOGGING
+            if(this.producer != null) {
+                this.producer.flush();
+                this.producer.close();
+                this.producer = null;
+            }
+        }
+    }
+
+    /**
+     * Create a new {@link KafkaSslBuildWrapper}.
+     */
+    @DataBoundConstructor
+    public KafkaSslBuildWrapper(String kafkaServers, String kafkaTopic, String metadata, String securityProtocol, String sslTruststoreLocation,
+    		String sslTruststorePassword) {
+        this.kafkaServers = kafkaServers;
+        this.kafkaTopic = kafkaTopic;
+        this.metadata = metadata;
+        this.securityProtocol = securityProtocol;
+        this.sslTruststoreLocation = sslTruststoreLocation;
+        this.sslTruststorePassword= sslTruststorePassword;
+    }
+    
+    public String getKafkaServers() {
+        return this.kafkaServers == null ? "127.0.0.1:9092" : this.kafkaServers;
+    }
+
+    public String getKafkaTopic() {
+        return this.kafkaTopic == null ? "buildlogs" : this.kafkaTopic;
+    }
+
+
+    public String getMetadata() {
+        return this.kafkaTopic == null ? "" : this.metadata;
+    }
+    
+    public String getSecurityProtocol() {
+		return this.securityProtocol;
+	}
+
+	public String getSslTruststoreLocation() {
+		return this.sslTruststoreLocation;
+	}
+
+	public String getSslTruststorePassword() {
+		return this.sslTruststorePassword;
+	}
+
+	@Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
+
+    @Override
+    public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) 
+        throws IOException, InterruptedException 
+    {
+        this.buildId = build.getNumber();
+        this.jobName = build.getParent().getName();
+        // DO ANYTHING TO SETUP
+        this.producer = new KafkaWrapper(this.buildId, this.jobName, this.metadata, this.kafkaServers, this.kafkaTopic,
+        		this.securityProtocol, this.sslTruststoreLocation, this.sslTruststorePassword);
+        context.setDisposer(new CleanupDisposer(this.producer));
+    }
+
+
+    /**
+     * Registers {@link KafkaBuildWrapper} as a {@link BuildWrapper}.
+     */
+    @Extension @Symbol("withKafkaLog")
+    public static final class DescriptorImpl extends BuildWrapperDescriptor {
+
+        public DescriptorImpl() {
+            super(KafkaSslBuildWrapper.class);
+            load();
+        }
+
+        @Override
+        public boolean configure(final StaplerRequest req, final JSONObject formData) throws FormException {
+            return true;
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckName(@QueryParameter final String value) {
+            return FormValidation.ok();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.DisplayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isApplicable(AbstractProject<?, ?> item) {
+            return true;
+        }
+    }
+
+
+
+    @Override
+    public ConsoleLogFilter createLoggerDecorator(Run<?, ?> build) {
+        return new KafkaConsoleLogFilter(this.producer);
+    }
+
+	
+}

--- a/src/main/java/hudson/plugins/kafkalogs/KafkaSslBuildWrapper.java
+++ b/src/main/java/hudson/plugins/kafkalogs/KafkaSslBuildWrapper.java
@@ -118,7 +118,7 @@ public class KafkaSslBuildWrapper extends SimpleBuildWrapper implements Serializ
 
 
     /**
-     * Registers {@link KafkaBuildWrapper} as a {@link BuildWrapper}.
+     * Registers {@link KafkaSslBuildWrapper} as a {@link BuildWrapper}.
      */
     @Extension @Symbol("withKafkaLog")
     public static final class DescriptorImpl extends BuildWrapperDescriptor {

--- a/src/main/java/hudson/plugins/kafkalogs/KafkaWrapper.java
+++ b/src/main/java/hudson/plugins/kafkalogs/KafkaWrapper.java
@@ -26,7 +26,10 @@ package hudson.plugins.kafkalogs;
 import java.util.Properties;
 import java.lang.Thread;
 import java.io.Serializable;
+
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.json.simple.JSONArray;
@@ -39,8 +42,12 @@ public final class KafkaWrapper implements Serializable {
 	private String kafkaTopic;
 	private String jobName;
 	private String metadata;
+	private  String securityProtocol;
+	private  String sslTruststoreLoc;
+	private  String sslTrustStorePass;
 	private int buildId;
 	private transient Producer<String, String> producer;
+	
 
 	public KafkaWrapper(int buildId, String jobName, String metadata, String kafkaServers, String kafkaTopic) {
 		this.kafkaServers = kafkaServers;
@@ -55,6 +62,30 @@ public final class KafkaWrapper implements Serializable {
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "jenkins");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        this.producer = new KafkaProducer<>(props);
+	}
+	
+	public KafkaWrapper(int buildId, String jobName, String metadata, String kafkaServers, String kafkaTopic, 
+			String securityProtocol, String sslTruststoreLoc, String sslTrustStorePass) {
+		this.kafkaServers = kafkaServers;
+		this.kafkaTopic = kafkaTopic;
+		this.jobName = jobName;
+		this.buildId = buildId;
+		this.metadata = metadata;
+		this.securityProtocol= securityProtocol;
+		this.sslTruststoreLoc = sslTruststoreLoc;
+		this.sslTrustStorePass = sslTrustStorePass;
+		
+        Thread.currentThread().setContextClassLoader(null);
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServers);
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "jenkins");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      //configure the following three settings for SSL Encryption
+        props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+        props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, sslTruststoreLoc);
+        props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,  sslTrustStorePass);
         this.producer = new KafkaProducer<>(props);
 	}
 

--- a/src/main/resources/hudson/plugins/kafkalogs/KafkaSslBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/kafkalogs/KafkaSslBuildWrapper/config.jelly
@@ -1,0 +1,22 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="Kafka Servers" field="kafkaServers">
+      <f:textbox/>
+	</f:entry>
+	<f:entry title="Kafka Topic" field="kafkaTopic">
+      <f:textbox/>
+	</f:entry>
+	<f:entry title="Kafka Metadata" field="metadata">
+      <f:textbox/>
+	</f:entry>
+	<f:entry title="security protocol" field="securityProtocol">
+      <f:textbox/>
+	</f:entry>
+	<f:entry title="ssl.truststore.location" field="sslTruststoreLocation">
+      <f:textbox/>
+	</f:entry>
+	<f:entry title="ssl.truststore.password" field="sslTruststorePassword">
+      <f:textbox/>
+	</f:entry>
+	
+</j:jelly>


### PR DESCRIPTION
Enabling SSL  for jenkins  plugin to ship build logs to kafka.

Created new class to pass SSL  parameters to the broker KafkaSslBuildWrapper .  Use this class to  pass client's trust store and  the trust store password.  

Consumers client using same client truststore will consume the messages.
 ```
wrap([$class: 'KafkaSslBuildWrapper', kafkaServers: 'manrope1.fyre.ibm.com:9093', 
                       kafkaTopic: 'kafka-security-topic', metadata:'Other info to send..', 
                       securityProtocol: 'SSL', 
                       sslTruststoreLocation: 'C://ssl/kafka.client.truststore.jks', 
                       sslTruststorePassword: 'clientpass']) {
                            echo 'We are ssl encrypted now!!!'
                            echo 'Hello!!!'
                            echo 'Lets check now!!!'
                        } 
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
